### PR TITLE
Revert "[IMP] calendar: Set default value for start* and stop* date/date...

### DIFF
--- a/addons/calendar/calendar.py
+++ b/addons/calendar/calendar.py
@@ -764,7 +764,7 @@ class calendar_event(osv.Model):
         if not tz:  # tz can have a value False, so dont do it in the default value of get !
             context['tz'] = self.pool.get('res.users').read(cr, SUPERUSER_ID, uid, ['tz'])['tz']
             tz = context['tz']
-        tz = tools.ustr(tz).encode('utf-8')  # make safe for str{p,f}time()
+        tz = tools.ustr(tz).encode('utf-8') # make safe for str{p,f}time()
 
         format_date, format_time = self.get_date_formats(cr, uid, context=context)
         date = fields.datetime.context_timestamp(cr, uid, datetime.strptime(start, tools.DEFAULT_SERVER_DATETIME_FORMAT), context=context)
@@ -960,8 +960,6 @@ class calendar_event(osv.Model):
         'active': 1,
         'user_id': lambda self, cr, uid, ctx: uid,
         'partner_ids': _get_default_partners,
-        'start_datetime': lambda *x: datetime.now(),
-        'stop_datetime': lambda *x: datetime.now() + relativedelta(hours=1),
     }
 
     def _check_closing_date(self, cr, uid, ids, context=None):


### PR DESCRIPTION
...time. Else field.function start and stop are not setted by default while they are required."

This reverts commit b1adf3a95e94568e618d635ce575398e94c3967e.

Not so simple, 'search' don't find recurrent events with this change
