### PR TITLE
[FIX] crm: Company name in crm lead

### DIFF
--- a/addons/crm/crm_lead.py
+++ b/addons/crm/crm_lead.py
@@ -310,9 +310,10 @@ class crm_lead(format_address, osv.osv):
         values = {}
         if partner_id:
             partner = self.pool.get('res.partner').browse(cr, uid, partner_id, context=context)
+            partner_name = (partner.parent_id and partner.parent_id.name) or (partner.is_company and partner.name) or False
             values = {
-                'partner_name': partner.parent_id.name if partner.parent_id else partner.name,
-                'contact_name': partner.name if partner.parent_id else False,
+                'partner_name': partner_name,
+                'contact_name': (not partner.is_company and partner.name) or False,
                 'title': partner.title and partner.title.id or False,
                 'street': partner.street,
                 'street2': partner.street2,


### PR DESCRIPTION
The onchange on partner field must not fill the company name if
the partner is not a company or not in a company. If the partner
is not a company, the contact name field must be filled with the
partner name.

opw:644878
